### PR TITLE
Fix corner placement on non-16:9 and scaled monitors

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -12,6 +12,28 @@ namespace RoundedWindowsEdges
         private TrayIcon trayIcon;
         private MainWindow[] mainWindows;
 
+        // ── Win32 helpers for per-monitor DPI ────────────────────────────────
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct POINT { public int X, Y; }
+
+        // Returns the monitor handle nearest to a given point.
+        [DllImport("user32.dll")]
+        private static extern IntPtr MonitorFromPoint(POINT pt, uint dwFlags);
+        private const uint MONITOR_DEFAULTTONEAREST = 2;
+
+        // Returns the effective DPI for a specific monitor (Windows 8.1+).
+        [DllImport("Shcore.dll", SetLastError = true)]
+        private static extern int GetDpiForMonitor(IntPtr hMonitor, int dpiType, out uint dpiX, out uint dpiY);
+        private const int MDT_EFFECTIVE_DPI = 0;
+
+        // Fallback: reads DPI from a GDI device context (always primary monitor).
+        [DllImport("gdi32.dll")]
+        private static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
+        private const int LOGPIXELSX = 88;
+
+        // ── Startup / shutdown ────────────────────────────────────────────────
+
         protected override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
@@ -24,10 +46,24 @@ namespace RoundedWindowsEdges
                 var screen = Forms.Screen.AllScreens[i];
                 var bounds = screen.Bounds;
 
-                var dpiScale = GetDpiScale(screen);
-                Debug.WriteLine($"Screen {i}: Bounds = {bounds}, DPI Scale = {dpiScale}");
+                // BUG FIX 1 & 2:
+                // GetDpiScaleForScreen queries *this monitor's* DPI via
+                // GetDpiForMonitor instead of always reading the primary
+                // monitor's DC. The resulting scale is then applied to the
+                // bounds so the Rect is expressed in WPF logical units
+                // (96-DPI baseline) rather than raw physical pixels.
+                // Previously dpiScale was computed but never used, which meant
+                // every window was positioned/sized in physical pixels inside
+                // WPF's logical coordinate space — correct only when DPI = 100 %.
+                double dpiScale = GetDpiScaleForScreen(screen);
+                Debug.WriteLine($"Screen {i}: Bounds={bounds}, DPI Scale={dpiScale}");
 
-                var rect = new Rect(bounds.X, bounds.Y, bounds.Width, bounds.Height);
+                var rect = new Rect(
+                    bounds.X      / dpiScale,
+                    bounds.Y      / dpiScale,
+                    bounds.Width  / dpiScale,
+                    bounds.Height / dpiScale
+                );
 
                 if (mainWindows[i] == null)
                 {
@@ -42,28 +78,49 @@ namespace RoundedWindowsEdges
         protected override void OnExit(ExitEventArgs e)
         {
             foreach (var window in mainWindows)
-            {
                 window.Close();
-            }
 
             trayIcon.Dispose();
             base.OnExit(e);
         }
 
-        private double GetDpiScale(Forms.Screen screen)
+        // ── DPI helpers ───────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Returns the effective DPI scale for the given screen (1.0 = 100 %,
+        /// 1.25 = 125 %, 1.5 = 150 %, etc.).
+        /// Uses GetDpiForMonitor (Windows 8.1+) so every monitor in a
+        /// multi-monitor setup reports its own DPI independently.
+        /// Falls back to the GDI primary-monitor DPI on older Windows versions.
+        /// </summary>
+        private static double GetDpiScaleForScreen(Forms.Screen screen)
         {
+            // Sample the centre of this screen to identify its monitor handle.
+            var pt = new POINT
+            {
+                X = screen.Bounds.Left + screen.Bounds.Width  / 2,
+                Y = screen.Bounds.Top  + screen.Bounds.Height / 2
+            };
+
+            IntPtr hMonitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+
+            // GetDpiForMonitor returns 0 (S_OK) on success.
+            if (GetDpiForMonitor(hMonitor, MDT_EFFECTIVE_DPI, out uint dpiX, out uint _) == 0)
+            {
+                Debug.WriteLine($"  GetDpiForMonitor -> {dpiX} DPI");
+                return dpiX / 96.0;
+            }
+
+            // Fallback: GDI gives the primary monitor's DPI; acceptable when
+            // all monitors share the same DPI setting.
             using (Graphics g = Graphics.FromHwnd(IntPtr.Zero))
             {
-                IntPtr desktop = g.GetHdc();
-                int dpiX = GetDeviceCaps(desktop, 88); 
-                int dpiY = GetDeviceCaps(desktop, 90);
-                g.ReleaseHdc(desktop);
-
-                return dpiX / 96.0; 
+                IntPtr hdc = g.GetHdc();
+                int dpi = GetDeviceCaps(hdc, LOGPIXELSX);
+                g.ReleaseHdc(hdc);
+                Debug.WriteLine($"  GetDeviceCaps fallback -> {dpi} DPI");
+                return dpi / 96.0;
             }
         }
-
-        [DllImport("gdi32.dll")]
-        static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
     }
 }


### PR DESCRIPTION
On monitors with a non-16:9 aspect ratio or any DPI scaling above 100%, only the top-left corner rendered in the correct position. The other three corners (TR, BR, BL) were misplaced or off-screen entirely.

There were two bugs in App.xaml.cs:
1- DPI scale was computed but never applied. Forms.Screen.Bounds returns physical pixels, but WPF positions and sizes windows in logical units (96 DPI baseline). The conversion factor (dpiScale) was calculated and then silently ignored — the window was being sized in raw physical pixels inside WPF's logical coordinate space. This made the overlay window larger than the screen on any scaled display, pushing TR/BR/BL off their correct corners. TL always appeared correct because it anchors to the window's origin (0, 0) regardless of size.
2- DPI was always read from the primary monitor. GetDpiScale used Graphics.FromHwnd(IntPtr.Zero), which returns a DC for the primary monitor only. On multi-monitor setups where each screen has a different DPI setting, every secondary window received the wrong scale factor.

Fix:
Replaced GetDpiScale with GetDpiScaleForScreen, which uses MonitorFromPoint + GetDpiForMonitor (Windows 8.1+) to query each monitor's DPI independently, with a GDI fallback for older systems.
Applied the resulting scale factor when constructing the Rect passed to each MainWindow, converting physical pixel bounds into correct WPF logical units.